### PR TITLE
@SuppressWarnings(PMD.UnusedPrivateField)

### DIFF
--- a/src/main/java/com/jcabi/email/Envelope.java
+++ b/src/main/java/com/jcabi/email/Envelope.java
@@ -278,7 +278,6 @@ public interface Envelope {
         /**
          * Guava cache.
          */
-        @SuppressWarnings("PMD.UnusedPrivateField")
         private static final Cache<Envelope, Message> CACHE =
             CacheBuilder.newBuilder()
                 .expireAfterWrite(1L, TimeUnit.HOURS)


### PR DESCRIPTION
#29 This constant is in use. The ```@SuppressWarnings``` annotation is not needed.