### PR TITLE
Switched from Dumbster to Greenmail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>dumbster</groupId>
-            <artifactId>dumbster</artifactId>
-            <version>1.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
             <version>1.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
             <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -99,7 +99,9 @@ public interface Protocol {
      * SMTPS protocol.
      * @todo #36:30min Write unit test for email sending with SMTPS protocol
      *  using Greenmail mock server (see http://www.icegreen.com/greenmail/
-     *  for Greenmail docs and example code).
+     *  for Greenmail docs and example code). SMTPS was implemented in ticket
+     *  #33 but was not unit tested since the previous mock server (Dumbster)
+     *  did not support SSL.
      */
     final class SMTPS implements Protocol {
         /**

--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -97,6 +97,9 @@ public interface Protocol {
 
     /**
      * SMTPS protocol.
+     * @todo #36:30min Write unit test for email sending with SMTPS protocol
+     *  using Greenmail mock server (see http://www.icegreen.com/greenmail/
+     *  for Greenmail docs and example code).
      */
     final class SMTPS implements Protocol {
         /**

--- a/src/test/java/com/jcabi/email/wire/SMTPTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPTest.java
@@ -44,6 +44,7 @@ import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
 import java.io.IOException;
 import java.net.ServerSocket;
+import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import org.hamcrest.MatcherAssert;
@@ -58,14 +59,6 @@ import org.junit.Test;
  * @since 1.0
  */
 public final class SMTPTest {
-    /**
-     * Bind address for the smtp server.
-     */
-    private static final String BIND_ADDRESS = "localhost";
-    /**
-     * Constant three.
-     */
-    private static final int THREE = 3;
 
     /**
      * SMTP can send email through SMTP.
@@ -73,10 +66,12 @@ public final class SMTPTest {
      */
     @Test
     public void sendsEmailToSmtpServer() throws Exception {
+        final String bind = "localhost";
+        final int received = 3;
         final int port = SMTPTest.port();
         final GreenMail server = new GreenMail(
             new ServerSetup(
-                port, SMTPTest.BIND_ADDRESS,
+                port, bind,
                 ServerSetup.PROTOCOL_SMTP
             )
         );
@@ -85,7 +80,7 @@ public final class SMTPTest {
             new Postman.Default(
                 new SMTP(
                     new Token("", "")
-                        .access(new Protocol.SMTP(SMTPTest.BIND_ADDRESS, port))
+                        .access(new Protocol.SMTP(bind, port))
                 )
             ).send(
                 new Envelope.Safe(
@@ -102,15 +97,15 @@ public final class SMTPTest {
             final MimeMessage[] messages = server.getReceivedMessages();
             MatcherAssert.assertThat(
                 messages.length,
-                Matchers.is(SMTPTest.THREE)
+                Matchers.is(received)
             );
-            for (int idx = 0; idx < messages.length; ++idx) {
+            for (final Message msg : messages) {
                 MatcherAssert.assertThat(
-                    messages[idx].getFrom()[0].toString(),
+                    msg.getFrom()[0].toString(),
                     Matchers.containsString("<test-from@jcabi.com>")
                 );
                 MatcherAssert.assertThat(
-                    messages[idx].getSubject(),
+                    msg.getSubject(),
                     Matchers.containsString("test me")
                 );
             }

--- a/src/test/java/com/jcabi/email/wire/SMTPTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPTest.java
@@ -28,15 +28,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jcabi.email.wire;
-import java.io.IOException;
-import java.net.ServerSocket;
-
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
 
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -51,6 +42,13 @@ import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
+import java.io.IOException;
+import java.net.ServerSocket;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * Test case for {@link SMTP}.
@@ -60,27 +58,34 @@ import com.jcabi.email.stamp.StSubject;
  * @since 1.0
  */
 public final class SMTPTest {
-	private static final String BIND_ADDRESS = "localhost";
     /**
-     * SMTP can send emails through SMTP.
+     * Bind address for the smtp server.
+     */
+    private static final String BIND_ADDRESS = "localhost";
+    /**
+     * Constant three.
+     */
+    private static final int THREE = 3;
+
+    /**
+     * SMTP can send email through SMTP.
      * @throws Exception If fails
      */
     @Test
     public void sendsEmailToSmtpServer() throws Exception {
-
         final int port = SMTPTest.port();
-        GreenMail server = new GreenMail(
-                                   new ServerSetup(
-                                       port, BIND_ADDRESS,
-                                       ServerSetup.PROTOCOL_SMTP
-                                   )
-                               );
+        final GreenMail server = new GreenMail(
+            new ServerSetup(
+                port, SMTPTest.BIND_ADDRESS,
+                ServerSetup.PROTOCOL_SMTP
+            )
+        );
         server.start();
         try {
             new Postman.Default(
                 new SMTP(
                     new Token("", "")
-                        .access(new Protocol.SMTP(BIND_ADDRESS, port))
+                        .access(new Protocol.SMTP(SMTPTest.BIND_ADDRESS, port))
                 )
             ).send(
                 new Envelope.Safe(
@@ -95,18 +100,20 @@ public final class SMTPTest {
                 )
             );
             final MimeMessage[] messages = server.getReceivedMessages();
-            MatcherAssert.assertThat(messages.length, Matchers.is(3));
-            for(int i=0;i<messages.length;i++) {
-            	MatcherAssert.assertThat(
-                    messages[i].getFrom()[0].toString(),
+            MatcherAssert.assertThat(
+                messages.length,
+                Matchers.is(SMTPTest.THREE)
+            );
+            for (int idx = 0; idx < messages.length; ++idx) {
+                MatcherAssert.assertThat(
+                    messages[idx].getFrom()[0].toString(),
                     Matchers.containsString("<test-from@jcabi.com>")
                 );
                 MatcherAssert.assertThat(
-                    messages[i].getSubject(),
+                    messages[idx].getSubject(),
                     Matchers.containsString("test me")
                 );
             }
-
         } finally {
             server.stop();
         }


### PR DESCRIPTION
This PR is for issue #36 
Switched from Dumbster mock smtp server to Greenmail (the proposed replacement, ``javamail-mock2``, contains merely some mock classes for unit testing mailing, but no actual mock server).

Changes done:

1) Replaced dependency in pom.xml
2) Fixed SMTP wire unit test to use Greenmail and also renamed it (it's simply a unit test for sending a mail to a SMTP server, I don't know why the name and javadoc said something about sending errors?) 
3) Changed assert in the test from 1 received mail to 3 (difference of mock server implementation -> Greenmail counts a mail with 3 recipients as 3 separate mails).
4) Added puzzle for unit testing of SMTPS protocol.