### PR TITLE
SMTPS wire and unit test for SMTPS protocol

### DIFF
--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -42,11 +42,13 @@ import javax.net.ssl.SSLSocketFactory;
  * <pre> Postman postman = new Postman.Default(
  *   new SMTP(
  *     new Token("user", "password").access(
- *       new Protocol.SMTPS("smtp.gmail.com", 587)
+ *       new Protocol.SMTP("bind", "port")
  *     )
  *   )
  * );
  * </pre>
+ * For <b>SMTPS</b> use the {@link com.jcabi.email.wire.SMTPS} wire and
+ * {@link Protocol.SMTPS} respectively.
  *
  * @author Piotr Kotlicki (piotr.kotlicki@gmail.com)
  * @version $Id$
@@ -97,11 +99,6 @@ public interface Protocol {
 
     /**
      * SMTPS protocol.
-     * @todo #36:30min Write unit test for email sending with SMTPS protocol
-     *  using Greenmail mock server (see http://www.icegreen.com/greenmail/
-     *  for Greenmail docs and example code). SMTPS was implemented in ticket
-     *  #33 but was not unit tested since the previous mock server (Dumbster)
-     *  did not support SSL.
      */
     final class SMTPS implements Protocol {
         /**

--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -124,7 +124,9 @@ public interface Protocol {
         @Override
         public Map<String, String> entries() {
             return new ImmutableMap.Builder<String, String>()
-                .putAll(new Protocol.SMTP(this.host, this.port).entries())
+                .put("mail.smtps.auth", Boolean.TRUE.toString())
+                .put("mail.smtps.host", this.host)
+                .put("mail.smtps.port", Integer.toString(this.port))
                 .put(
                     "mail.smtp.ssl.checkserveridentity",
                     Boolean.TRUE.toString()

--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -48,7 +48,13 @@ import javax.net.ssl.SSLSocketFactory;
  * );
  * </pre>
  * For <b>SMTPS</b> use the {@link com.jcabi.email.wire.SMTPS} wire and
- * {@link Protocol.SMTPS} respectively.
+ * {@link Protocol.SMTPS} respectively. SMTPS protocol should work only with
+ * the SMTPS wire because the wire uses the "smtps" transport to make the
+ * connection to the mail server:
+ * <pre>
+ *     final Transport transport = this.session.getTransport("smtps");
+ *     transport.connect();
+ * </pre>
  *
  * @author Piotr Kotlicki (piotr.kotlicki@gmail.com)
  * @version $Id$

--- a/src/main/java/com/jcabi/email/Token.java
+++ b/src/main/java/com/jcabi/email/Token.java
@@ -47,7 +47,7 @@ import lombok.ToString;
  * <pre> Postman postman = new Postman.Default(
  *   new SMTP(
  *     new Token("user", "password").access(
- *       new Protocol.SMTPS("smtp.gmail.com", 587)
+ *       new Protocol.SMTP("bind", "port")
  *     )
  *   )
  * );

--- a/src/main/java/com/jcabi/email/wire/SMTP.java
+++ b/src/main/java/com/jcabi/email/wire/SMTP.java
@@ -66,10 +66,10 @@ public final class SMTP implements Wire {
 
     /**
      * Public ctor.
-     * @param sess Session.
+     * @param session Session.
      */
-    public SMTP(final Session sess) {
-        this.session = sess;
+    public SMTP(final Session session) {
+        this.session = session;
     }
 
     @Override

--- a/src/main/java/com/jcabi/email/wire/SMTP.java
+++ b/src/main/java/com/jcabi/email/wire/SMTP.java
@@ -60,7 +60,7 @@ import javax.mail.Transport;
 public final class SMTP implements Wire {
 
     /**
-     * SMTP password.
+     * Mail session.
      */
     private final transient Session session;
 

--- a/src/main/java/com/jcabi/email/wire/SMTPS.java
+++ b/src/main/java/com/jcabi/email/wire/SMTPS.java
@@ -29,8 +29,6 @@
  */
 package com.jcabi.email.wire;
 
-import com.jcabi.aspects.Immutable;
-import com.jcabi.aspects.Loggable;
 import com.jcabi.email.Wire;
 import java.io.IOException;
 import javax.mail.MessagingException;
@@ -38,26 +36,24 @@ import javax.mail.Session;
 import javax.mail.Transport;
 
 /**
- * SMTP wire.
+ * SMTPS wire.
  *
  * <p>This is how you're supposed to use it:
  *
  * <pre> Postman postman = new Postman.Default(
- *   new SMTP(
+ *   new SMTPS(
  *     new Token("user", "password").access(
- *       new Protocol.SMTP("bind", "port")
+ *       new Protocol.SMTPS("smtp.gmail.com", 587)
  *     )
  *   )
  * );
  * </pre>
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0
+ * @since 1.9
  */
-@Immutable
-@Loggable(Loggable.DEBUG)
-public final class SMTP implements Wire {
+public final class SMTPS implements Wire {
 
     /**
      * SMTP password.
@@ -68,19 +64,18 @@ public final class SMTP implements Wire {
      * Public ctor.
      * @param sess Session.
      */
-    public SMTP(final Session sess) {
+    public SMTPS(final Session sess) {
         this.session = sess;
     }
 
     @Override
     public Transport connect() throws IOException {
         try {
-            final Transport transport = this.session.getTransport("smtp");
+            final Transport transport = this.session.getTransport("smtps");
             transport.connect();
             return transport;
         } catch (final MessagingException ex) {
             throw new IOException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/wire/SMTPS.java
+++ b/src/main/java/com/jcabi/email/wire/SMTPS.java
@@ -56,7 +56,7 @@ import javax.mail.Transport;
 public final class SMTPS implements Wire {
 
     /**
-     * SMTP password.
+     * Mail session.
      */
     private final transient Session session;
 

--- a/src/main/java/com/jcabi/email/wire/SMTPS.java
+++ b/src/main/java/com/jcabi/email/wire/SMTPS.java
@@ -62,10 +62,10 @@ public final class SMTPS implements Wire {
 
     /**
      * Public ctor.
-     * @param sess Session.
+     * @param session Session.
      */
-    public SMTPS(final Session sess) {
-        this.session = sess;
+    public SMTPS(final Session session) {
+        this.session = session;
     }
 
     @Override

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -32,6 +32,7 @@ package com.jcabi.email.wire;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import com.jcabi.email.Envelope;
 import com.jcabi.email.Postman;
 import com.jcabi.email.Protocol;
@@ -43,12 +44,15 @@ import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.security.Security;
+
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -75,7 +79,12 @@ public final class SMTPSTest {
             "ssl.SocketFactory.provider",
             DummySSLSocketFactory.class.getName()
         );
-        final GreenMail server = new GreenMail(ServerSetup.SMTPS);
+        final GreenMail server = new GreenMail(
+            new ServerSetup(
+                port, bind, 
+                ServerSetup.PROTOCOL_SMTPS
+            )
+        ); 
         server.start();
         try {
             new Postman.Default(

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.email.wire;
 
+import com.icegreen.greenmail.util.DummySSLSocketFactory;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.jcabi.email.Envelope;
@@ -42,8 +43,7 @@ import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
-import java.io.IOException;
-import java.net.ServerSocket;
+import java.security.Security;
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
@@ -52,35 +52,39 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link SMTP}.
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * Test case for {@link SMTPS}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
+ * @since 1.9
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @since 1.0
  */
-public final class SMTPTest {
+public final class SMTPSTest {
 
     /**
-     * SMTP postman can send email through SMTP wire.
+     * SMTPS postman can send email through SMTPS wire.
      * @throws Exception If fails
      */
     @Test
-    public void sendsEmailToSmtpServer() throws Exception {
+    public void sendsEmailToThroughSmtps() throws Exception {
         final String bind = "localhost";
         final int received = 3;
-        final int port = SMTPTest.port();
+        final int port = 465;
+        Security.setProperty(
+            "ssl.SocketFactory.provider",
+            DummySSLSocketFactory.class.getName()
+        );
         final GreenMail server = new GreenMail(
             new ServerSetup(
                 port, bind,
-                ServerSetup.PROTOCOL_SMTP
+                ServerSetup.PROTOCOL_SMTPS
             )
         );
         server.start();
         try {
             new Postman.Default(
-                new SMTP(
+                new SMTPS(
                     new Token("", "")
-                        .access(new Protocol.SMTP(bind, port))
+                        .access(new Protocol.SMTPS(bind, port))
                 )
             ).send(
                 new Envelope.Safe(
@@ -111,17 +115,6 @@ public final class SMTPTest {
             }
         } finally {
             server.stop();
-        }
-    }
-
-    /**
-     * Allocate free port.
-     * @return Found port.
-     * @throws IOException In case of error.
-     */
-    private static int port() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
         }
     }
 

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -67,13 +67,16 @@ public final class SMTPSTest {
         final String bind = "localhost";
         final int received = 1;
         final int port = SMTPSTest.port();
+        final int timeout = 3000;
         Security.setProperty(
             "ssl.SocketFactory.provider",
             DummySSLSocketFactory.class.getName()
         );
-        final GreenMail server = new GreenMail(
-            new ServerSetup(port, bind, ServerSetup.PROTOCOL_SMTPS)
+        final ServerSetup setup = new ServerSetup(
+            port, bind, ServerSetup.PROTOCOL_SMTPS
         );
+        setup.setServerStartupTimeout(timeout);
+        final GreenMail server = new GreenMail(setup);
         server.start();
         try {
             new Postman.Default(

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -32,7 +32,6 @@ package com.jcabi.email.wire;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
-import com.icegreen.greenmail.util.ServerSetupTest;
 import com.jcabi.email.Envelope;
 import com.jcabi.email.Postman;
 import com.jcabi.email.Protocol;
@@ -44,15 +43,12 @@ import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.security.Security;
-
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -81,10 +77,10 @@ public final class SMTPSTest {
         );
         final GreenMail server = new GreenMail(
             new ServerSetup(
-                port, bind, 
+                port, bind,
                 ServerSetup.PROTOCOL_SMTPS
             )
-        ); 
+        );
         server.start();
         try {
             new Postman.Default(

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -43,6 +43,8 @@ import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.security.Security;
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
@@ -68,17 +70,12 @@ public final class SMTPSTest {
     public void sendsEmailToThroughSmtps() throws Exception {
         final String bind = "localhost";
         final int received = 3;
-        final int port = 465;
+        final int port = SMTPSTest.port();
         Security.setProperty(
             "ssl.SocketFactory.provider",
             DummySSLSocketFactory.class.getName()
         );
-        final GreenMail server = new GreenMail(
-            new ServerSetup(
-                port, bind,
-                ServerSetup.PROTOCOL_SMTPS
-            )
-        );
+        final GreenMail server = new GreenMail(ServerSetup.SMTPS);
         server.start();
         try {
             new Postman.Default(
@@ -115,6 +112,17 @@ public final class SMTPSTest {
             }
         } finally {
             server.stop();
+        }
+    }
+
+    /**
+     * Allocate free port.
+     * @return Found port.
+     * @throws IOException In case of error.
+     */
+    private static int port() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
         }
     }
 

--- a/src/test/java/com/jcabi/email/wire/SMTPSTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPSTest.java
@@ -36,10 +36,7 @@ import com.jcabi.email.Envelope;
 import com.jcabi.email.Postman;
 import com.jcabi.email.Protocol;
 import com.jcabi.email.Token;
-import com.jcabi.email.enclosure.EnHTML;
 import com.jcabi.email.enclosure.EnPlain;
-import com.jcabi.email.stamp.StBCC;
-import com.jcabi.email.stamp.StCC;
 import com.jcabi.email.stamp.StRecipient;
 import com.jcabi.email.stamp.StSender;
 import com.jcabi.email.stamp.StSubject;
@@ -47,7 +44,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.security.Security;
 import javax.mail.Message;
-import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -63,23 +59,20 @@ import org.junit.Test;
 public final class SMTPSTest {
 
     /**
-     * SMTPS postman can send email through SMTPS wire.
+     * SMTPS postman can send an email to the server through SMTPS wire.
      * @throws Exception If fails
      */
     @Test
-    public void sendsEmailToThroughSmtps() throws Exception {
+    public void sendsEmailToTheServerThroughSmtps() throws Exception {
         final String bind = "localhost";
-        final int received = 3;
+        final int received = 1;
         final int port = SMTPSTest.port();
         Security.setProperty(
             "ssl.SocketFactory.provider",
             DummySSLSocketFactory.class.getName()
         );
         final GreenMail server = new GreenMail(
-            new ServerSetup(
-                port, bind,
-                ServerSetup.PROTOCOL_SMTPS
-            )
+            new ServerSetup(port, bind, ServerSetup.PROTOCOL_SMTPS)
         );
         server.start();
         try {
@@ -93,17 +86,13 @@ public final class SMTPSTest {
                     new Envelope.MIME()
                         .with(new StSender("from <test-from@jcabi.com>"))
                         .with(new StRecipient("to", "test-to@jcabi.com"))
-                        .with(new StCC(new InternetAddress("cc <c@jcabi.com>")))
-                        .with(new StBCC("bcc <bcc@jcabi.com>"))
                         .with(new StSubject("test subject: test me"))
                         .with(new EnPlain("hello"))
-                        .with(new EnHTML("<p>how are you?</p>"))
                 )
             );
             final MimeMessage[] messages = server.getReceivedMessages();
             MatcherAssert.assertThat(
-                messages.length,
-                Matchers.is(received)
+                messages.length, Matchers.is(received)
             );
             for (final Message msg : messages) {
                 MatcherAssert.assertThat(
@@ -111,8 +100,7 @@ public final class SMTPSTest {
                     Matchers.containsString("<test-from@jcabi.com>")
                 );
                 MatcherAssert.assertThat(
-                    msg.getSubject(),
-                    Matchers.containsString("test me")
+                    msg.getSubject(),  Matchers.containsString("test me")
                 );
             }
         } finally {

--- a/src/test/java/com/jcabi/email/wire/SMTPTest.java
+++ b/src/test/java/com/jcabi/email/wire/SMTPTest.java
@@ -69,12 +69,12 @@ public final class SMTPTest {
         final String bind = "localhost";
         final int received = 3;
         final int port = SMTPTest.port();
-        final GreenMail server = new GreenMail(
-            new ServerSetup(
-                port, bind,
-                ServerSetup.PROTOCOL_SMTP
-            )
+        final int timeout = 3000;
+        final ServerSetup setup = new ServerSetup(
+            port, bind, ServerSetup.PROTOCOL_SMTP
         );
+        setup.setServerStartupTimeout(timeout);
+        final GreenMail server = new GreenMail(setup);
         server.start();
         try {
             new Postman.Default(


### PR DESCRIPTION
PR for #46 
Also added SMTPS wire, since Protocol.SMTPS does not work with ``smtp`` transport, it needs ``smtps`` transport.

Updated javadocs too since they were not ok.

Fixed bug in Protocol.SMTPS which was setting some properties for smtp protocol, not for smtps.

**More details:** 

**1)** This SMTPS Wire is needed since the Greenmail unit test does not work with the SMTP wire .

This issue was not found before since apparently Gmail server works fine if called with the SMTP wire and SMTPS protocol.

I am not sure why Gmail worked with the SMTP wire, but it works with this SMTPS wire as well, so I would leave this as it is now, since it makes sense the most: If you send an email through SMTPS protocol, a smtps transport should be used.

**2)** Properties from Protocol.SMTP were not ok since the smtps transport used in the SMTPS wire looks up the properties with ".smtps." in the middle, not ".smtp.". If it does not find them, the defaults are used (localhost and port 465) and so the unit test passed locally, but failed on the linux server since you need root priviledge to access ports < 1024 .
