### PR TITLE
Upgrade dependencies to latest stable versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.38.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-email</artifactId>
   <version>2.0-SNAPSHOT</version>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>com.icegreen</groupId>
       <artifactId>greenmail</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.15</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -166,7 +166,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.26.0</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes combine.children="append">

--- a/src/main/java/com/jcabi/email/Enclosure.java
+++ b/src/main/java/com/jcabi/email/Enclosure.java
@@ -27,5 +27,4 @@ public interface Enclosure {
      * @throws MessagingException If fails
      */
     MimeBodyPart part() throws MessagingException;
-
 }

--- a/src/main/java/com/jcabi/email/Envelope.java
+++ b/src/main/java/com/jcabi/email/Envelope.java
@@ -36,6 +36,8 @@ import lombok.ToString;
  * {@link com.jcabi.email.Envelope.Safe}.
  *
  * @since 1.0
+ * @checkstyle QualifyInnerClassCheck (500 lines)
+ * @checkstyle ConstructorsCodeFreeCheck (500 lines)
  */
 @Immutable
 @FunctionalInterface
@@ -136,7 +138,7 @@ public interface Envelope {
          * @since 1.3
          */
         public Mime with(final Stamp stamp) {
-            return new Mime(
+            return new Envelope.Mime(
                 this.stamps.with(stamp),
                 this.encs
             );
@@ -149,7 +151,7 @@ public interface Envelope {
          * @since 1.3
          */
         public Mime with(final Enclosure enc) {
-            return new Mime(
+            return new Envelope.Mime(
                 this.stamps,
                 this.encs.with(enc)
             );
@@ -333,5 +335,4 @@ public interface Envelope {
             return msg;
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/Postman.java
+++ b/src/main/java/com/jcabi/email/Postman.java
@@ -49,6 +49,7 @@ import lombok.ToString;
  * );</pre>
  *
  * @since 1.0
+ * @checkstyle QualifyInnerClassCheck (500 lines)
  */
 @Immutable
 @FunctionalInterface
@@ -137,5 +138,4 @@ public interface Postman {
             }
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/Stamp.java
+++ b/src/main/java/com/jcabi/email/Stamp.java
@@ -30,5 +30,4 @@ public interface Stamp {
      * @throws MessagingException If fails
      */
     void attach(Message message) throws MessagingException;
-
 }

--- a/src/main/java/com/jcabi/email/Wire.java
+++ b/src/main/java/com/jcabi/email/Wire.java
@@ -36,5 +36,4 @@ public interface Wire {
      * @throws IOException If fails
      */
     Transport connect() throws IOException;
-
 }

--- a/src/main/java/com/jcabi/email/enclosure/EnBinary.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnBinary.java
@@ -18,6 +18,7 @@ import lombok.ToString;
  * Binary enclosure in MIME envelope.
  *
  * @since 1.0
+ * @checkstyle ConstructorsCodeFreeCheck (100 lines)
  */
 @Immutable
 @ToString

--- a/src/main/java/com/jcabi/email/enclosure/EnHtml.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnHtml.java
@@ -76,5 +76,4 @@ public final class EnHtml implements Enclosure {
         mime.addHeader("Content-Type", ctype);
         return mime;
     }
-
 }

--- a/src/main/java/com/jcabi/email/enclosure/EnPlain.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnPlain.java
@@ -68,5 +68,4 @@ public final class EnPlain implements Enclosure {
         mime.addHeader("Content-Type", "text/plain");
         return mime;
     }
-
 }

--- a/src/main/java/com/jcabi/email/postman/PostNoDrafts.java
+++ b/src/main/java/com/jcabi/email/postman/PostNoDrafts.java
@@ -53,5 +53,4 @@ public final class PostNoDrafts implements Postman {
             throw new IOException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/postman/PostNoLoops.java
+++ b/src/main/java/com/jcabi/email/postman/PostNoLoops.java
@@ -81,5 +81,4 @@ public final class PostNoLoops implements Postman {
         }
         return intersect;
     }
-
 }

--- a/src/main/java/com/jcabi/email/stamp/StBcc.java
+++ b/src/main/java/com/jcabi/email/stamp/StBcc.java
@@ -19,6 +19,8 @@ import lombok.ToString;
  * Stamp for a MIME envelope, with a BCC recipient.
  *
  * @since 1.0
+ * @checkstyle ConstructorsCodeFreeCheck (200 lines)
+ * @checkstyle ConstructorsOrderCheck (200 lines)
  */
 @Immutable
 @ToString
@@ -99,5 +101,4 @@ public final class StBcc implements Stamp {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/stamp/StCc.java
+++ b/src/main/java/com/jcabi/email/stamp/StCc.java
@@ -19,6 +19,8 @@ import lombok.ToString;
  * Stamp for a MIME envelope, with a CC recipient.
  *
  * @since 1.0
+ * @checkstyle ConstructorsCodeFreeCheck (200 lines)
+ * @checkstyle ConstructorsOrderCheck (200 lines)
  */
 @Immutable
 @ToString
@@ -99,5 +101,4 @@ public final class StCc implements Stamp {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/stamp/StRecipient.java
+++ b/src/main/java/com/jcabi/email/stamp/StRecipient.java
@@ -19,6 +19,8 @@ import lombok.ToString;
  * Stamp for a MIME envelope, with a recipient.
  *
  * @since 1.0
+ * @checkstyle ConstructorsCodeFreeCheck (200 lines)
+ * @checkstyle ConstructorsOrderCheck (200 lines)
  */
 @Immutable
 @ToString
@@ -103,5 +105,4 @@ public final class StRecipient implements Stamp {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/stamp/StReplyTo.java
+++ b/src/main/java/com/jcabi/email/stamp/StReplyTo.java
@@ -18,6 +18,8 @@ import lombok.ToString;
  * Stamp for a MIME envelope, with a replyTo.
  *
  * @since 1.8
+ * @checkstyle ConstructorsCodeFreeCheck (100 lines)
+ * @checkstyle ConstructorsOrderCheck (100 lines)
  */
 @Immutable
 @ToString

--- a/src/main/java/com/jcabi/email/stamp/StSender.java
+++ b/src/main/java/com/jcabi/email/stamp/StSender.java
@@ -19,6 +19,8 @@ import lombok.ToString;
  * Stamp for a MIME envelope, with a sender.
  *
  * @since 1.0
+ * @checkstyle ConstructorsCodeFreeCheck (200 lines)
+ * @checkstyle ConstructorsOrderCheck (200 lines)
  */
 @Immutable
 @ToString
@@ -94,5 +96,4 @@ public final class StSender implements Stamp {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/stamp/StSubject.java
+++ b/src/main/java/com/jcabi/email/stamp/StSubject.java
@@ -73,5 +73,4 @@ public final class StSubject implements Stamp {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/email/wire/Smtp.java
+++ b/src/main/java/com/jcabi/email/wire/Smtp.java
@@ -55,5 +55,4 @@ public final class Smtp implements Wire {
             throw new IOException(ex);
         }
     }
-
 }

--- a/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
@@ -42,5 +42,4 @@ final class EnBinaryTest {
             Matchers.endsWith("привет")
         );
     }
-
 }

--- a/src/test/java/com/jcabi/email/enclosure/EnPlainTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnPlainTest.java
@@ -23,9 +23,8 @@ final class EnPlainTest {
      */
     @Test
     void createsPlainMimePart() throws Exception {
-        final MimeBodyPart part = new EnPlain("hello, друг").part();
         MatcherAssert.assertThat(
-            part.getContent().toString(),
+            new EnPlain("hello, друг").part().getContent().toString(),
             Matchers.endsWith("друг")
         );
     }

--- a/src/test/java/com/jcabi/email/postman/PostNoLoopsTest.java
+++ b/src/test/java/com/jcabi/email/postman/PostNoLoopsTest.java
@@ -51,5 +51,4 @@ final class PostNoLoopsTest {
         );
         Mockito.verify(post).send(Mockito.any(Envelope.class));
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StBccTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StBccTest.java
@@ -101,5 +101,4 @@ final class StBccTest {
         final int last = encoded.lastIndexOf('?');
         return encoded.substring(encoded.lastIndexOf('?', last - 1) + 1, last);
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StCcTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StCcTest.java
@@ -101,5 +101,4 @@ final class StCcTest {
         final int last = encoded.lastIndexOf('?');
         return encoded.substring(encoded.lastIndexOf('?', last - 1) + 1, last);
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StHeaderTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StHeaderTest.java
@@ -36,5 +36,4 @@ final class StHeaderTest {
             Matchers.equalTo(value)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StRecipientTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StRecipientTest.java
@@ -95,5 +95,4 @@ final class StRecipientTest {
         final int last = encoded.lastIndexOf('?');
         return encoded.substring(encoded.lastIndexOf('?', last - 1) + 1, last);
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StSenderTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StSenderTest.java
@@ -93,5 +93,4 @@ final class StSenderTest {
         final int last = encoded.lastIndexOf('?');
         return encoded.substring(encoded.lastIndexOf('?', last - 1) + 1, last);
     }
-
 }

--- a/src/test/java/com/jcabi/email/stamp/StSubjectTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StSubjectTest.java
@@ -84,5 +84,4 @@ final class StSubjectTest {
         final int last = encoded.lastIndexOf('?');
         return encoded.substring(encoded.lastIndexOf('?', last - 1) + 1, last);
     }
-
 }

--- a/src/test/java/com/jcabi/email/wire/SmtpTest.java
+++ b/src/test/java/com/jcabi/email/wire/SmtpTest.java
@@ -40,12 +40,12 @@ final class SmtpTest {
     @Test
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void sendsEmailToSmtpServer() throws Exception {
-        final int port = SmtpTest.port();
         final ServerSetup setup = new ServerSetup(
-            port, "localhost", ServerSetup.PROTOCOL_SMTP
+            SmtpTest.port(), "localhost", ServerSetup.PROTOCOL_SMTP
         );
         setup.setServerStartupTimeout(3000);
         final GreenMail server = new GreenMail(setup);
+        server.getManagers().getUserManager().setAuthRequired(false);
         server.start();
         try {
             new Postman.Default(
@@ -100,5 +100,4 @@ final class SmtpTest {
             return socket.getLocalPort();
         }
     }
-
 }

--- a/src/test/java/com/jcabi/email/wire/SmtpsTest.java
+++ b/src/test/java/com/jcabi/email/wire/SmtpsTest.java
@@ -40,13 +40,12 @@ final class SmtpsTest {
     @Disabled
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void sendsEmailToTheServerThroughSmtps() throws Exception {
-        final int port = SmtpsTest.port();
         Security.setProperty(
             "ssl.SocketFactory.provider",
             DummySSLSocketFactory.class.getName()
         );
         final ServerSetup setup = new ServerSetup(
-            port, "localhost", ServerSetup.PROTOCOL_SMTPS
+            SmtpsTest.port(), "localhost", ServerSetup.PROTOCOL_SMTPS
         );
         setup.setServerStartupTimeout(3000);
         final GreenMail server = new GreenMail(setup);
@@ -80,7 +79,7 @@ final class SmtpsTest {
                     Matchers.containsString("<test-from@jcabi.com>")
                 );
                 MatcherAssert.assertThat(
-                    msg.getSubject(),  Matchers.containsString("test me")
+                    msg.getSubject(), Matchers.containsString("test me")
                 );
             }
         } finally {
@@ -99,5 +98,4 @@ final class SmtpsTest {
             return socket.getLocalPort();
         }
     }
-
 }


### PR DESCRIPTION
Upgrade parent pom 1.38.0->1.44.0, greenmail 1.5.0->1.6.15, slf4j-reload4j 2.0.16->2.0.17, qulice 0.25.1->0.26.0. Update CI workflows. Fix qulice 0.26.0 checks. Adapt tests to greenmail 1.6.15 API (auth now required by default).