### PR TITLE
Bump greenmail and qulice, fix new lint and Windows test issues

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -18,13 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
-        exclude:
-          # Qulice 0.26.0 checkstyle fails on Windows runners under Java 21
-          # while succeeding under Java 17. Tracking issue upstream; exclude
-          # this combination until the upstream fix lands.
-          - os: windows-2022
-            java: 21
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>com.icegreen</groupId>
       <artifactId>greenmail</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.15</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -166,7 +166,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.26.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>findbugs:.*</exclude>

--- a/src/main/java/com/jcabi/email/Enclosure.java
+++ b/src/main/java/com/jcabi/email/Enclosure.java
@@ -11,7 +11,6 @@ import javax.mail.internet.MimeBodyPart;
 
 /**
  * Enclosure in MIME envelope.
- *
  * @see com.jcabi.email.enclosure.EnPlain
  * @see com.jcabi.email.enclosure.EnBinary
  * @see EnHtml

--- a/src/main/java/com/jcabi/email/Envelope.java
+++ b/src/main/java/com/jcabi/email/Envelope.java
@@ -71,6 +71,7 @@ public interface Envelope {
     @EqualsAndHashCode(of = "encs")
     @Loggable(Loggable.DEBUG)
     final class Mime implements Envelope {
+
         /**
          * List of stamps.
          */
@@ -169,6 +170,7 @@ public interface Envelope {
     @EqualsAndHashCode(of = "origin")
     @Loggable(Loggable.DEBUG)
     final class Strict implements Envelope {
+
         /**
          * Origin env.
          */
@@ -217,6 +219,7 @@ public interface Envelope {
     @EqualsAndHashCode(of = "origin")
     @Loggable(Loggable.DEBUG)
     final class Safe implements Envelope {
+
         /**
          * Origin env.
          */
@@ -265,6 +268,7 @@ public interface Envelope {
     @EqualsAndHashCode(of = "origin")
     @Loggable(Loggable.DEBUG)
     final class Constant implements Envelope {
+
         /**
          * Guava cache.
          */
@@ -313,6 +317,7 @@ public interface Envelope {
     @EqualsAndHashCode(of = "env")
     @Loggable(Loggable.DEBUG)
     final class Draft implements Envelope {
+
         /**
          * Origin env.
          */

--- a/src/main/java/com/jcabi/email/Postman.java
+++ b/src/main/java/com/jcabi/email/Postman.java
@@ -92,6 +92,7 @@ public interface Postman {
     @EqualsAndHashCode(of = "wire")
     @Loggable(Loggable.DEBUG)
     final class Default implements Postman {
+
         /**
          * Wire.
          */

--- a/src/main/java/com/jcabi/email/Protocol.java
+++ b/src/main/java/com/jcabi/email/Protocol.java
@@ -38,8 +38,13 @@ import javax.net.ssl.SSLSocketFactory;
 public interface Protocol {
 
     /**
+     * String value of {@code true}, for SMTP property values.
+     */
+    String TRUE = "true";
+
+    /**
      * Guarantee of access for protocol.
-     * @return Entry parameters.
+     * @return Entry parameters
      */
     Map<String, String> entries();
 
@@ -48,6 +53,7 @@ public interface Protocol {
      * @since 1.0
      */
     final class Smtp implements Protocol {
+
         /**
          * SMTP host.
          */
@@ -71,7 +77,7 @@ public interface Protocol {
         @Override
         public Map<String, String> entries() {
             return new ImmutableMap.Builder<String, String>()
-                .put("mail.smtp.auth", Boolean.TRUE.toString())
+                .put("mail.smtp.auth", Protocol.TRUE)
                 .put("mail.smtp.host", this.host)
                 .put("mail.smtp.port", Integer.toString(this.port))
                 .build();
@@ -83,6 +89,7 @@ public interface Protocol {
      * @since 1.0
      */
     final class Smtps implements Protocol {
+
         /**
          * SMTPS host.
          */
@@ -106,22 +113,17 @@ public interface Protocol {
         @Override
         public Map<String, String> entries() {
             return new ImmutableMap.Builder<String, String>()
-                .put("mail.smtps.auth", Boolean.TRUE.toString())
+                .put("mail.smtps.auth", Protocol.TRUE)
                 .put("mail.smtps.host", this.host)
                 .put("mail.smtps.port", Integer.toString(this.port))
-                .put("mail.smtp.starttls.required", "true")
+                .put("mail.smtp.starttls.required", Protocol.TRUE)
                 .put("mail.smtp.ssl.protocols", "TLSv1.2")
-                .put("mail.smtp.starttls.enable", "true")
-                .put(
-                    "mail.smtp.ssl.checkserveridentity",
-                    Boolean.TRUE.toString()
-                ).put(
-                    "mail.smtp.socketFactory.class",
-                    SSLSocketFactory.class.getName()
-                ).put(
-                    "mail.smtp.socketFactory.port",
-                    Integer.toString(this.port)
-                ).put("mail.smtp.socketFactory.fallback", "false").build();
+                .put("mail.smtp.starttls.enable", Protocol.TRUE)
+                .put("mail.smtp.ssl.checkserveridentity", Protocol.TRUE)
+                .put("mail.smtp.socketFactory.class", SSLSocketFactory.class.getName())
+                .put("mail.smtp.socketFactory.port", Integer.toString(this.port))
+                .put("mail.smtp.socketFactory.fallback", "false")
+                .build();
         }
     }
 }

--- a/src/main/java/com/jcabi/email/Stamp.java
+++ b/src/main/java/com/jcabi/email/Stamp.java
@@ -12,7 +12,6 @@ import javax.mail.MessagingException;
 
 /**
  * Stamp for a MIME envelope.
- *
  * @see com.jcabi.email.stamp.StRecipient
  * @see com.jcabi.email.stamp.StSender
  * @see StCc

--- a/src/main/java/com/jcabi/email/Token.java
+++ b/src/main/java/com/jcabi/email/Token.java
@@ -58,8 +58,8 @@ public final class Token {
 
     /**
      * Access for given protocol.
-     * @param protocol Protocol.
-     * @return Session.
+     * @param protocol Protocol
+     * @return Session
      */
     public Session access(final Protocol protocol) {
         final Properties props = new Properties();
@@ -77,6 +77,7 @@ public final class Token {
      * @since 1.0
      */
     private static final class Verification extends Authenticator {
+
         /**
          * User name.
          */

--- a/src/main/java/com/jcabi/email/enclosure/EnBinary.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnBinary.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Binary enclosure in MIME envelope.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/enclosure/EnHtml.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnHtml.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 
 /**
  * HTML enclosure in MIME envelope.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/enclosure/EnPlain.java
+++ b/src/main/java/com/jcabi/email/enclosure/EnPlain.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Plain enclosure in MIME envelope.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/enclosure/package-info.java
+++ b/src/main/java/com/jcabi/email/enclosure/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Enclosures.
- *
  * @since 1.2
  */
 package com.jcabi.email.enclosure;

--- a/src/main/java/com/jcabi/email/postman/PostNoDrafts.java
+++ b/src/main/java/com/jcabi/email/postman/PostNoDrafts.java
@@ -18,7 +18,6 @@ import lombok.ToString;
 
 /**
  * Postman that ignores drafts.
- *
  * @since 1.6
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/postman/PostNoLoops.java
+++ b/src/main/java/com/jcabi/email/postman/PostNoLoops.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 
 /**
  * Postman that ignores loops (sender equals to recipient).
- *
  * @since 1.6
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/postman/package-info.java
+++ b/src/main/java/com/jcabi/email/postman/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Postmen.
- *
  * @since 1.6
  */
 package com.jcabi.email.postman;

--- a/src/main/java/com/jcabi/email/stamp/StBcc.java
+++ b/src/main/java/com/jcabi/email/stamp/StBcc.java
@@ -17,7 +17,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a BCC recipient.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StCc.java
+++ b/src/main/java/com/jcabi/email/stamp/StCc.java
@@ -17,7 +17,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a CC recipient.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StHeader.java
+++ b/src/main/java/com/jcabi/email/stamp/StHeader.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a header name and value.
- *
  * @since 1.6.2
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StRecipient.java
+++ b/src/main/java/com/jcabi/email/stamp/StRecipient.java
@@ -17,7 +17,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a recipient.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StReplyTo.java
+++ b/src/main/java/com/jcabi/email/stamp/StReplyTo.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a replyTo.
- *
  * @since 1.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StSender.java
+++ b/src/main/java/com/jcabi/email/stamp/StSender.java
@@ -17,7 +17,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a sender.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/StSubject.java
+++ b/src/main/java/com/jcabi/email/stamp/StSubject.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Stamp for a MIME envelope, with a subject.
- *
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/email/stamp/package-info.java
+++ b/src/main/java/com/jcabi/email/stamp/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Stamps.
- *
  * @since 1.2
  */
 package com.jcabi.email.stamp;

--- a/src/main/java/com/jcabi/email/wire/Smtp.java
+++ b/src/main/java/com/jcabi/email/wire/Smtp.java
@@ -39,7 +39,7 @@ public final class Smtp implements Wire {
 
     /**
      * Public ctor.
-     * @param session Session.
+     * @param session Session
      */
     public Smtp(final Session session) {
         this.session = session;

--- a/src/main/java/com/jcabi/email/wire/Smtps.java
+++ b/src/main/java/com/jcabi/email/wire/Smtps.java
@@ -35,7 +35,7 @@ public final class Smtps implements Wire {
 
     /**
      * Public ctor.
-     * @param session Session.
+     * @param session Session
      */
     public Smtps(final Session session) {
         this.session = session;

--- a/src/main/java/com/jcabi/email/wire/package-info.java
+++ b/src/main/java/com/jcabi/email/wire/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Wires.
- *
  * @since 1.4
  */
 package com.jcabi.email.wire;

--- a/src/test/java/com/jcabi/email/EnvelopeTest.java
+++ b/src/test/java/com/jcabi/email/EnvelopeTest.java
@@ -24,7 +24,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link Envelope}.
- *
  * @since 1.4
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
@@ -5,6 +5,7 @@
 package com.jcabi.email.enclosure;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -24,7 +25,9 @@ import org.junit.jupiter.api.io.TempDir;
 final class EnBinaryTest {
 
     @Test
-    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    @SuppressWarnings({
+        "PMD.UnitTestContainsTooManyAsserts", "PMD.UnnecessaryLocalRule"
+    })
     void addsFileToMessage(@TempDir final Path temp) throws Exception {
         Assumptions.assumeTrue("UTF-8".equals(Charset.defaultCharset().name()));
         final File file = temp.resolve("test.txt").toFile();
@@ -36,9 +39,11 @@ final class EnBinaryTest {
             part.getFileName(),
             Matchers.endsWith("другу.pdf")
         );
-        MatcherAssert.assertThat(
-            IOUtils.toString(part.getInputStream(), StandardCharsets.UTF_8),
-            Matchers.endsWith("привет")
-        );
+        try (InputStream stream = part.getInputStream()) {
+            MatcherAssert.assertThat(
+                IOUtils.toString(stream, StandardCharsets.UTF_8),
+                Matchers.endsWith("привет")
+            );
+        }
     }
 }

--- a/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnBinaryTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link EnBinary}.
- *
  * @since 1.3.2
  */
 final class EnBinaryTest {

--- a/src/test/java/com/jcabi/email/enclosure/EnHtmlTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnHtmlTest.java
@@ -5,6 +5,8 @@
 package com.jcabi.email.enclosure;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.mail.internet.MimeBodyPart;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -12,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link EnHtml}.
- *
  * @since 1.8.2
  */
 final class EnHtmlTest {
@@ -24,10 +25,10 @@ final class EnHtmlTest {
     @Test
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void createsHtmlMimePartWithCustomEncoding() throws Exception {
-        final String charset = "KOI8-R";
+        final Charset charset = Charset.forName("KOI8-R");
         final MimeBodyPart part = new EnHtml(
             "<p>hello, приятель</p>",
-            charset
+            charset.name()
         ).part();
         final String substring = "приятель";
         MatcherAssert.assertThat(
@@ -41,7 +42,7 @@ final class EnHtmlTest {
             Matchers.containsString(substring)
         );
         MatcherAssert.assertThat(
-            new String(bytes.toByteArray(), "UTF-8"),
+            new String(bytes.toByteArray(), StandardCharsets.UTF_8),
             Matchers.not(Matchers.containsString(substring))
         );
     }

--- a/src/test/java/com/jcabi/email/enclosure/EnPlainTest.java
+++ b/src/test/java/com/jcabi/email/enclosure/EnPlainTest.java
@@ -5,6 +5,8 @@
 package com.jcabi.email.enclosure;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.mail.internet.MimeBodyPart;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -12,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link EnPlain}.
- *
  * @since 1.3.2
  */
 final class EnPlainTest {
@@ -36,10 +37,10 @@ final class EnPlainTest {
     @Test
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void createsPlainMimePartWithCustomEncoding() throws Exception {
-        final String charset = "KOI8-R";
+        final Charset charset = Charset.forName("KOI8-R");
         final MimeBodyPart part = new EnPlain(
             "hello, приятель",
-            charset
+            charset.name()
         ).part();
         final String suffix = "приятель";
         MatcherAssert.assertThat(
@@ -53,7 +54,7 @@ final class EnPlainTest {
             Matchers.endsWith(suffix)
         );
         MatcherAssert.assertThat(
-            new String(bytes.toByteArray(), "UTF-8"),
+            new String(bytes.toByteArray(), StandardCharsets.UTF_8),
             Matchers.not(Matchers.endsWith(suffix))
         );
     }

--- a/src/test/java/com/jcabi/email/enclosure/package-info.java
+++ b/src/test/java/com/jcabi/email/enclosure/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Enclosures, tests.
- *
  * @since 1.2
  */
 package com.jcabi.email.enclosure;

--- a/src/test/java/com/jcabi/email/package-info.java
+++ b/src/test/java/com/jcabi/email/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Object-oriented email sending SDK, tests.
- *
  * @since 1.0
  */
 package com.jcabi.email;

--- a/src/test/java/com/jcabi/email/postman/PostNoLoopsTest.java
+++ b/src/test/java/com/jcabi/email/postman/PostNoLoopsTest.java
@@ -13,7 +13,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link PostNoLoops}.
- *
  * @since 1.6
  */
 final class PostNoLoopsTest {

--- a/src/test/java/com/jcabi/email/postman/package-info.java
+++ b/src/test/java/com/jcabi/email/postman/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Postmen, tests.
- *
  * @since 1.6
  */
 package com.jcabi.email.postman;

--- a/src/test/java/com/jcabi/email/stamp/StBccTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StBccTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StBcc}.
- *
  * @since 1.3.1
  */
 final class StBccTest {

--- a/src/test/java/com/jcabi/email/stamp/StCcTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StCcTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StCc}.
- *
  * @since 1.3.1
  */
 final class StCcTest {

--- a/src/test/java/com/jcabi/email/stamp/StHeaderTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StHeaderTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StHeader}.
- *
  * @since 1.6.2
  */
 final class StHeaderTest {

--- a/src/test/java/com/jcabi/email/stamp/StRecipientTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StRecipientTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.jcabi.email.stamp.StRecipient}.
- *
  * @since 1.3.1
  */
 final class StRecipientTest {

--- a/src/test/java/com/jcabi/email/stamp/StReplyToTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StReplyToTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StReplyTo}.
- *
  * @since 1.8
  */
 final class StReplyToTest {

--- a/src/test/java/com/jcabi/email/stamp/StSenderTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StSenderTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.jcabi.email.stamp.StSender}.
- *
  * @since 1.3.1
  */
 final class StSenderTest {

--- a/src/test/java/com/jcabi/email/stamp/StSubjectTest.java
+++ b/src/test/java/com/jcabi/email/stamp/StSubjectTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.jcabi.email.stamp.StSubject}.
- *
  * @since 1.3.1
  */
 final class StSubjectTest {

--- a/src/test/java/com/jcabi/email/stamp/package-info.java
+++ b/src/test/java/com/jcabi/email/stamp/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Stamps, tests.
- *
  * @since 1.3.1
  */
 package com.jcabi.email.stamp;

--- a/src/test/java/com/jcabi/email/wire/SmtpTest.java
+++ b/src/test/java/com/jcabi/email/wire/SmtpTest.java
@@ -46,10 +46,11 @@ final class SmtpTest {
         setup.setServerStartupTimeout(3000);
         final GreenMail server = new GreenMail(setup);
         server.start();
+        server.setUser("test-from@jcabi.com", "user", "password");
         try {
             new Postman.Default(
                 new Smtp(
-                    new Token("", "").access(
+                    new Token("user", "password").access(
                         new Protocol.Smtp(
                             server.getSmtp().getBindTo(),
                             server.getSmtp().getPort()
@@ -90,8 +91,8 @@ final class SmtpTest {
 
     /**
      * Allocate free port.
-     * @return Found port.
-     * @throws IOException In case of error.
+     * @return Found port
+     * @throws IOException In case of error
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static int port() throws IOException {

--- a/src/test/java/com/jcabi/email/wire/SmtpsTest.java
+++ b/src/test/java/com/jcabi/email/wire/SmtpsTest.java
@@ -89,8 +89,8 @@ final class SmtpsTest {
 
     /**
      * Allocate free port.
-     * @return Found port.
-     * @throws IOException In case of error.
+     * @return Found port
+     * @throws IOException In case of error
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static int port() throws IOException {

--- a/src/test/java/com/jcabi/email/wire/package-info.java
+++ b/src/test/java/com/jcabi/email/wire/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Wires, tests.
- *
  * @since 1.4
  */
 package com.jcabi.email.wire;


### PR DESCRIPTION
@yegor256 — this PR brings `jcabi-email` up to date with the rest of the jcabi ecosystem (qulice 0.27.6, parent jcabi 1.44.0) and fixes the issues that surfaced along the way. CI is green on Linux, macOS, and Windows.

## Dependency / plugin upgrades

- `com.icegreen:greenmail` 1.5.0 -> 1.6.15. This is the latest stable on the 1.x line and stays on `javax.mail`, so no API change for jcabi-email itself. Migrating to greenmail 2.x would also flip the public API to `jakarta.mail`, which I left as a separate, larger effort.
- `com.qulice:qulice-maven-plugin` 0.26.0 -> 0.27.6 to align with what jcabi/jcabi-parent and jcabi-urn use today.

## Test fixes the upgrades expose

- `SmtpTest.sendsEmailToSmtpServer` — GreenMail 1.6+ enforces SMTP authentication when credentials are supplied, so the previous `Token("", "")` fails with `535 5.7.8 Authentication credentials invalid`. The test now registers a matching user on the embedded server with `server.setUser(...)` and authenticates with that.
- `EnBinaryTest.addsFileToMessage` — `MimeBodyPart.attachFile` keeps a handle on the source file as long as the body part's `InputStream` is open, and the test was leaking that stream. POSIX silently allowed `@TempDir` to delete an open file, so the bug only manifested on Windows (the previous matrix dodged it by excluding `windows-2022 + JDK 21`). Wrapped the read in `try-with-resources`. This was a pre-existing issue, unrelated to the deps bump.

## Lint clean-up for qulice 0.27.6

Qulice 0.27.6 brings stricter Checkstyle / PMD / ErrorProne rules. Fixed the resulting violations in place (no new `@SuppressWarnings` for things qulice now flags, except for one `PMD.UnnecessaryLocalRule` on the `try`-with-resources stream above):

- `JavadocEmptyLineBeforeTagCheck` (35 occurrences) — removed the empty `* ` line before single-paragraph `@since`/`@see` blocks across `main` and `test` sources.
- `EmptyLineBeforeFirstMemberCheck` (9) — inserted the required blank line after the class/interface declaration in `Envelope`, `Postman`, `Protocol`, `Token`.
- `JavadocTagsDotCheck` (7) — removed trailing dots in `@param`/`@return`/`@throws` tags.
- `RegexpSinglelineCheck` — flattened the multi-line fluent `.put(\n...\n)` calls in `Protocol.Smtps#entries()`.
- ErrorProne `BooleanLiteral` (3) — replaced `Boolean.TRUE.toString()` with literal `"true"`. Extracted a `Protocol.TRUE` constant to keep PMD `AvoidDuplicateLiterals` happy.
- ErrorProne `JdkObsolete` and `StringCharset` (3) — switched `EnHtmlTest` and `EnPlainTest` to the `Charset`/`StandardCharsets` overloads of `new String(byte[], Charset)`.

## CI matrix

Qulice 0.27.6 is compiled against Java 21 (class file 65), so it can no longer be loaded under JDK 17. Dropped Java 17 from the `mvn` matrix. The previous `windows-2022 + JDK 21` exclude (workaround for a qulice 0.26.0 bug on Windows) was removed since 0.27.6 fixes it; the matrix is now the same shape as `jcabi-urn`'s — Java 21 across ubuntu-24.04, windows-2022, macos-15.

## Test plan

- `mvn --errors --batch-mode clean install -Pqulice` locally on JDK 21 (Linux): BUILD SUCCESS, 24 tests run, 1 skipped (the existing SMTPS skip), qulice clean.
- Full PR CI run on commit `2be4f1a`: 11/11 jobs green — `mvn` on ubuntu-24.04/windows-2022/macos-15 + actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint.
